### PR TITLE
Bone image upload UI #13

### DIFF
--- a/templates/bone.html
+++ b/templates/bone.html
@@ -11,6 +11,17 @@
         <h1>Bone Editor</h1>
         <button id="load-bones">Load Bones</button>
         <div id="bones-container"></div>
+
+        <!-- Image Upload Section -->
+        <div class="image-upload-container">
+            <h2>Upload Bone Image</h2>
+            <input type="file" id="imageUpload" accept="image/png, image/jpeg" />
+            <div id="imagePreview" class="image-preview">
+                <p>No image uploaded. Please upload a bone image.</p>
+            </div>
+            <p id="feedbackMessage" class="feedback"></p>
+        </div>
+    </div>
     </div>
 
     <script>
@@ -75,5 +86,6 @@
             });
         }
     </script>
+    <script src="uploadHandler.js"></script>
 </body>
 </html>

--- a/templates/uploadHandler.js
+++ b/templates/uploadHandler.js
@@ -42,8 +42,8 @@ function displayImage(file) {
             const img = document.createElement('img');
             img.src = e.target.result;
             img.alt = "Uploaded Bone Image";
-            img.style.maxWidth = "100%";
-            img.style.height = "100%";
+            img.style.maxWidth = "50%";
+            img.style.height = "auto";
 
             imagePreview.innerHTML = "";
             imagePreview.appendChild(img);

--- a/templates/uploadHandler.js
+++ b/templates/uploadHandler.js
@@ -1,0 +1,81 @@
+// Get the file input and preview elements
+const imageUpload = document.getElementById("imageUpload");
+const imagePreview = document.getElementById("imagePreview");
+const feedbackMessage = document.getElementById("feedbackMessage");
+
+// Maximum file size (10MB)
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB in bytes
+
+// Function to show feedback and update UI
+function showFeedback(message, isError = false) {
+    feedbackMessage.textContent = message;
+    feedbackMessage.style.color = isError ? '#dc3545' : '#28a745';
+}
+
+// Function to validate the uploaded file
+function validateFile(file) {
+    if (!file) {
+        showFeedback("No file selected. Please choose an image.", true);
+        return false;
+    }
+
+    if (!file.type.startsWith("image/")) {
+        showFeedback("Please upload a valid image file (PNG or JPEG).", true);
+        return false;
+    }
+
+    if (file.size > MAX_FILE_SIZE) {
+        showFeedback("The file size should not exceed 10MB. Please choose a smaller image.", true);
+        return false;
+    }
+
+    showFeedback(""); // Clear any previous feedback
+    return true;
+}
+
+// Function to display the uploaded image
+function displayImage(file) {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        
+        reader.onload = function (e) {
+            const img = document.createElement('img');
+            img.src = e.target.result;
+            img.alt = "Uploaded Bone Image";
+            img.style.maxWidth = "100%";
+            img.style.height = "100%";
+
+            imagePreview.innerHTML = "";
+            imagePreview.appendChild(img);
+            resolve();
+        };
+
+        reader.onerror = function (error) {
+            reject(error);
+        };
+
+        reader.readAsDataURL(file);
+    });
+}
+
+// Event listener for the image upload input
+imageUpload.addEventListener("change", async (event) => {
+    try {
+        const file = event.target.files[0];
+        
+        if (validateFile(file)) {
+            imagePreview.innerHTML = "<p>Processing your image...</p>";
+            await displayImage(file);
+        } else {
+            // Clear the file input if validation fails
+            imageUpload.value = '';
+            imagePreview.innerHTML = "<p>No valid image uploaded. Please try again.</p>";
+        }
+    } catch (error) {
+        console.error("An unexpected error occurred during file processing", error);
+        showFeedback("An unexpected error occurred. Please try again.", true);
+        imagePreview.innerHTML = "<p>Error processing image. Please try again.</p>";
+        // Clear the file input if an error occurs
+        imageUpload.value = '';
+    }
+});


### PR DESCRIPTION
**What was Changed**
- An "Upload Image" button was added to the UI, allowing users to upload a bone image. The button facilitates the uploading process, displays the uploaded image in a preview area within the editor, and handles error cases when an invalid file type or size is provided.

**Why it was Changed**
- The addition of the "Upload Image" button enables the foundational functionality needed for users to interact with the bone editing tool. It provides a user-friendly way to load images into the application, setting the stage for further development of annotation and editing features. 

**How it was Changed**
- Added an "Upload Image" button to the HTML, allowing users to select an image file. 
- File Validation: JavaScript was used to validate the uploaded file, checking the file type and size (with a limit of 10MB). If the file does not meet the criteria, an error message is displayed to the user.
- Displaying the Image: The displayImage function was implemented to read the image using FileReader and display it within a designated preview container. The function was designed to handle errors if the file fails to load.

**Technical Details**
The input element of type file was added to the HTML to allow image uploads.
JavaScript was used to add event listeners for the file upload process, validating the selected file and displaying the image or showing an error message.

**Dependencies**
No additional libraries or dependencies were added for this change.

**Testing**
- Tested with valid image files ensuring they upload and display correctly within the preview area.
- Tested with invalid file types to verify that the application displays an appropriate error message without crashing.
- Tested with large images (over 10MB) to confirm that the application prevents uploading and informs the user about the file size restriction.

![Screenshot 2024-10-14 155907](https://github.com/user-attachments/assets/e6c2d0d8-267e-4fcc-a381-ef557ce6b5c7)
![Screenshot 2024-10-14 161225](https://github.com/user-attachments/assets/0ad7c92c-47e3-4245-8bec-6db15c6c4dc6)
![Screenshot 2024-10-14 161333](https://github.com/user-attachments/assets/7c0d6ae9-db3d-41b6-8e9a-da6d0c93860c)
