### PR TITLE
Issue_79

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "chrome",
+            "request": "launch",
+            "name": "Launch Chrome against localhost",
+            "url": "http://localhost:8080",
+            "webRoot": "${workspaceFolder}"
+        }
+    ]
+}


### PR DESCRIPTION
### Description

Fixes #79 79 
I added statements that only allow the annotations in the position of the image to be extracted. I also brought down the size of the coed my condensing lines. 

**A pull request must contain the following elements.**

# 1. What was Changed
This will ensure that the only text that is being extracted in on the image, and are the annotations rather than the entire slide as we had originally. 
# 2. Why it was Changed
This is to make sure we have clear annotations and positions of those annotations for every slide. 

# 3. How it was Changed 
Setting a max and a min for both the X and Y  coordinate ensures that the script is not gathering text that is outside of the parameters. As long as the text on the slide is in the parameters then the script will spend it to the JSON.

# 4. Screenshots (if applicable)
Add the before and after screenshots for UI related changes