### PR TITLE
Issue Eighty Six

### DIFF
--- a/data_extraction/AutomatedExtractionScript.py
+++ b/data_extraction/AutomatedExtractionScript.py
@@ -2,8 +2,16 @@ import os
 import xml.etree.ElementTree as ET
 
 def extract_images_from_slide_xml(slide_xml_path, rels_xml_path, media_folder, output_folder):
+    """
+    Extracts images from a single slide XML file and renames them based on rId.
+
+    Args:
+        slide_xml_path (str): Path to the slide XML file.
+        rels_xml_path (str): Path to the relationships XML file for the slide.
+        media_folder (str): Path to the media folder containing images.
+        output_folder (str): Path to store extracted images.
+    """
     
-    # Step 1: Try parsing the slide XML file
     try:
         tree = ET.parse(slide_xml_path)
         root = tree.getroot()
@@ -14,18 +22,17 @@ def extract_images_from_slide_xml(slide_xml_path, rels_xml_path, media_folder, o
         print(f"[ERROR] Slide file not found: {slide_xml_path}")
         return
 
-    # Define XML namespaces (needed to properly find elements in the XML)
+    # Define XML namespaces
     ns = {'a': 'http://schemas.openxmlformats.org/drawingml/2006/main',
           'r': 'http://schemas.openxmlformats.org/officeDocument/2006/relationships'}
     
-    # Step 2: Find all <a:blip> tags, which reference images via the r:embed attribute
+    # Extract r:embed IDs that reference images
     embed_ids = [blip.attrib.get(f"{{{ns['r']}}}embed") for blip in root.findall(".//a:blip", ns) if blip.attrib.get(f"{{{ns['r']}}}embed")]
 
     if not embed_ids:
         print(f"[INFO] No images found in {slide_xml_path}. Skipping...")
-        return  # If no images are found, return early
+        return
 
-    # Step 3: Try parsing the relationships XML file
     try:
         rels_tree = ET.parse(rels_xml_path)
         rels_root = rels_tree.getroot()
@@ -36,32 +43,37 @@ def extract_images_from_slide_xml(slide_xml_path, rels_xml_path, media_folder, o
         print(f"[ERROR] Relationship file not found: {rels_xml_path}")
         return
 
-    # Extract XML namespace for relationships if one exists
+    # Extract XML namespace for relationships
     rels_ns = rels_root.tag.split('}')[0] + '}' if '}' in rels_root.tag else ''
 
-    # Step 4: Create a dictionary mapping rId (e.g., "rId8") to the actual image file path
+    # Map rId to the actual image filename
     relationships = {rel.attrib.get('Id', '').strip(): rel.attrib.get('Target', '').strip()
                      for rel in rels_root.findall(f".//{rels_ns}Relationship")}
 
-    # Step 5: Process each image reference found in the slide XML
+    # Extract slide number (e.g., "slide1" → 1)
+    slide_name = os.path.splitext(os.path.basename(slide_xml_path))[0]  # "slide1"
+    slide_number = slide_name.replace("slide", "")  # Extracts "1"
+
+    # Create output folder for slide images
+    slide_output_folder = os.path.join(output_folder, slide_name)
+    if not os.path.exists(slide_output_folder):
+        os.makedirs(slide_output_folder)
+
+    # Process each embedded image
     for embed_id in embed_ids:
         if embed_id in relationships:
-            target = relationships[embed_id]  # The actual image filename
-            image_path = os.path.join(media_folder, os.path.basename(target))  # Full path to the image
+            target = relationships[embed_id]
+            image_path = os.path.join(media_folder, os.path.basename(target))
 
             if os.path.exists(image_path):
-                # Extract slide name (e.g., "slide1" from "slide1.xml")
-                slide_name = os.path.splitext(os.path.basename(slide_xml_path))[0]
+                # Extract image extension (e.g., ".png", ".jpg")
+                image_extension = os.path.splitext(target)[-1]
 
-                # Create a dedicated folder for each slide in the output directory
-                slide_output_folder = os.path.join(output_folder, slide_name)
-                if not os.path.exists(slide_output_folder):
-                    os.makedirs(slide_output_folder)
+                # New image name: "slide1_rId8.png"
+                new_image_name = f"slide{slide_number}_{embed_id}{image_extension}"
+                image_output_path = os.path.join(slide_output_folder, new_image_name)
 
-                # Define output path for the extracted image
-                image_output_path = os.path.join(slide_output_folder, os.path.basename(target))
-
-                # Copy the image from ppt/media/ to the output folder
+                # Copy and rename the image
                 try:
                     with open(image_path, 'rb') as img_in, open(image_output_path, 'wb') as img_out:
                         img_out.write(img_in.read())
@@ -73,32 +85,40 @@ def extract_images_from_slide_xml(slide_xml_path, rels_xml_path, media_folder, o
         else:
             print(f"[WARNING] No relationship found for embed ID: {embed_id} (Referenced in {slide_xml_path})")
 
-#Processes all slides in the PowerPoint file and extracts images from each slide.
 def process_pptx_folders(slides_folder, rels_folder, media_folder, output_folder):
+    """
+    Processes all slides in the PowerPoint file and extracts images from each slide.
 
-    # Ensure the output folder exists
+    Args:
+        slides_folder (str): Path to the folder containing slide XML files.
+        rels_folder (str): Path to the folder containing relationships XML files.
+        media_folder (str): Path to the media folder containing images.
+        output_folder (str): Path to store extracted images.
+    """
+    
     if not os.path.exists(output_folder):
         os.makedirs(output_folder)
     
-    # Iterate through all slides in the slides folder
-    for slide_file in sorted(os.listdir(slides_folder)):  # Sorting ensures correct slide order
-        if slide_file.startswith("slide") and slide_file.endswith(".xml"):  # Check if it's a slide XML file
+    for slide_file in sorted(os.listdir(slides_folder)):  
+        if slide_file.startswith("slide") and slide_file.endswith(".xml"):
             slide_path = os.path.join(slides_folder, slide_file)
-            rels_path = os.path.join(rels_folder, slide_file + ".rels")  # Find the corresponding .rels file
+            rels_path = os.path.join(rels_folder, slide_file + ".rels")
             
             if os.path.exists(rels_path):
                 extract_images_from_slide_xml(slide_path, rels_path, media_folder, output_folder)
             else:
                 print(f"[WARNING] Missing relationship file: {rels_path}. Skipping slide {slide_file}.")
 
-# Main Execution Block
 if __name__ == "__main__":
+    """
+    Main execution block:
+    - Defines necessary folder paths.
+    - Calls process_pptx_folders() to extract images from all slides.
+    """
 
-    # Paths to relevant folders (these should be updated dynamically or via CLI arguments)
-    slides_folder = "/Users/burhankhan/Desktop/ppt/slides"  # Folder containing slide XML files
-    rels_folder = "/Users/burhankhan/Desktop/ppt/slides/_rels"  # Folder containing relationships XML files
-    media_folder = "/Users/burhankhan/Desktop/ppt/media"  # Folder containing media files
-    output_folder = "/Users/burhankhan/Desktop/AutomatedScript"  # Folder where images will be extracted
+    slides_folder = "/Users/burhankhan/Desktop/ppt/slides"
+    rels_folder = "/Users/burhankhan/Desktop/ppt/slides/_rels"
+    media_folder = "/Users/burhankhan/Desktop/ppt/media"
+    output_folder = "/Users/burhankhan/Desktop/AutomatedScript"
 
-    # Process all slides and extract images
     process_pptx_folders(slides_folder, rels_folder, media_folder, output_folder)

--- a/data_extraction/extract_ppt_annotations.py
+++ b/data_extraction/extract_ppt_annotations.py
@@ -1,85 +1,147 @@
+import os
 import xml.etree.ElementTree as ET
 import json
-import os
 
-def parse_slide_xml(xml_file, output_json_path):
-    # Load the XML file
-    tree = ET.parse(xml_file)
-    root = tree.getroot()
-    
-    # Define namespaces used in the XML
-    ns = {
-        'p': 'http://schemas.openxmlformats.org/presentationml/2006/main',
-        'a': 'http://schemas.openxmlformats.org/drawingml/2006/main'
+def extract_images_from_slide_xml(slide_xml_path, rels_xml_path, media_folder, output_folder, json_output):
+    """
+    Extract images from a slide XML, rename them, and write image details to a JSON file.
+    """
+    try:
+        tree = ET.parse(slide_xml_path)
+        root = tree.getroot()
+    except (ET.ParseError, FileNotFoundError) as e:
+        print(f"[ERROR] Failed to parse {slide_xml_path}: {e}")
+        return
+
+    ns = {'a': 'http://schemas.openxmlformats.org/drawingml/2006/main',
+          'r': 'http://schemas.openxmlformats.org/officeDocument/2006/relationships'}
+
+    # Extract image IDs from the slide XML
+    embed_ids = [blip.attrib.get(f"{{{ns['r']}}}embed") for blip in root.findall(".//a:blip", ns) if blip.attrib.get(f"{{{ns['r']}}}embed")]
+
+    if not embed_ids:
+        print(f"[INFO] No images found in {slide_xml_path}. Skipping...")
+        return
+
+    try:
+        rels_tree = ET.parse(rels_xml_path)
+        rels_root = rels_tree.getroot()
+    except (ET.ParseError, FileNotFoundError) as e:
+        print(f"[ERROR] Failed to parse {rels_xml_path}: {e}")
+        return
+
+    # Namespace for relationships
+    rels_ns = rels_root.tag.split('}')[0] + '}' if '}' in rels_root.tag else ''
+
+    # Map rId to actual image path
+    relationships = {rel.attrib.get('Id', '').strip(): rel.attrib.get('Target', '').strip()
+                     for rel in rels_root.findall(f".//{rels_ns}Relationship")}
+
+    # Extract slide number and set up output folder
+    slide_name = os.path.splitext(os.path.basename(slide_xml_path))[0]
+    slide_number = slide_name.replace("slide", "")
+    slide_output_folder = os.path.join(output_folder, slide_name)
+    os.makedirs(slide_output_folder, exist_ok=True)
+
+    # JSON structure for image and annotation details
+    slide_data = {
+        "slide": slide_name,
+        "images": [],
+        "annotations": []
     }
-    
-    annotations = []
-    middle_x_min, middle_x_max = 2000000, 6000000  # Define X range for middle
-    middle_y_min, middle_y_max = 1000000, 7000000  # Define Y range for middle
 
-    for sp in root.findall(".//p:sp", ns):
+    # Extract and rename images
+    for embed_id in embed_ids:
+        if embed_id in relationships:
+            target = relationships[embed_id]
+            image_path = os.path.join(media_folder, os.path.basename(target))
+
+            if os.path.exists(image_path):
+                image_extension = os.path.splitext(target)[-1]
+                new_image_name = f"slide{slide_number}_{embed_id}{image_extension}"
+                image_output_path = os.path.join(slide_output_folder, new_image_name)
+
+                try:
+                    with open(image_path, 'rb') as img_in, open(image_output_path, 'wb') as img_out:
+                        img_out.write(img_in.read())
+
+                    print(f"[SUCCESS] Extracted: {image_output_path}")
+                    
+                    # Add image metadata to JSON (Simplified)
+                    slide_data["images"].append({
+                        "rId": embed_id,
+                        "extracted_name": new_image_name
+                    })
+                except Exception as e:
+                    print(f"[ERROR] Failed to copy image {image_path}: {e}")
+            else:
+                print(f"[WARNING] Image not found: {image_path}")
+
+    # Extract annotations from slide XML
+    ns_p = {'p': 'http://schemas.openxmlformats.org/presentationml/2006/main',
+            'a': 'http://schemas.openxmlformats.org/drawingml/2006/main'}
+    middle_x_min, middle_x_max = 2000000, 6000000
+    middle_y_min, middle_y_max = 1000000, 7000000
+
+    for sp in root.findall(".//p:sp", ns_p):
         annotation = {}
-        
-        # Extract text, if present
-        text_elements = sp.findall(".//a:t", ns)
+        text_elements = sp.findall(".//a:t", ns_p)
         text = ''.join([t.text for t in text_elements if t.text])
-        
-        # Extract position and size
-        xfrm = sp.find(".//a:xfrm", ns)
+
+        xfrm = sp.find(".//a:xfrm", ns_p)
         if xfrm is not None:
-            pos = xfrm.find("a:off", ns)
-            size = xfrm.find("a:ext", ns)
+            pos = xfrm.find("a:off", ns_p)
+            size = xfrm.find("a:ext", ns_p)
             if pos is not None and size is not None:
                 x, y = int(pos.attrib.get("x", 0)), int(pos.attrib.get("y", 0))
                 width, height = int(size.attrib.get("cx", 0)), int(size.attrib.get("cy", 0))
-                
+
                 if middle_x_min <= x <= middle_x_max and middle_y_min <= y <= middle_y_max:
                     annotation["text"] = text
                     annotation["position"] = {"x": x, "y": y, "width": width, "height": height}
-                    
-                    # Extract fill color, if present
-                    fill_color = sp.find(".//a:solidFill/a:srgbClr", ns)
+
+                    # Extract fill color if present
+                    fill_color = sp.find(".//a:solidFill/a:srgbClr", ns_p)
                     if fill_color is not None:
                         annotation["color"] = fill_color.attrib.get("val")
-                    
-                    annotations.append(annotation)
-    
-    # Collect lines
-    for ln in root.findall(".//p:cxnSp", ns):
-        annotation = {"shape": "line"}
-        
-        # Extract line color
-        line_color = ln.find(".//a:ln/a:solidFill/a:srgbClr", ns)
-        if line_color is not None:
-            annotation["color"] = line_color.attrib.get("val")
-            annotations.append(annotation["color"])
-        
-        # Extract position and size
-        xfrm = ln.find(".//a:xfrm", ns)
-        if xfrm is not None:
-            pos = xfrm.find("a:off", ns)
-            size = xfrm.find("a:ext", ns)
-            if pos is not None and size is not None:
-                x, y = int(pos.attrib.get("x", 0)), int(pos.attrib.get("y", 0))
-                width, height = int(size.attrib.get("cx", 0)), int(size.attrib.get("cy", 0))
-                
-                if middle_x_min <= x <= middle_x_max and middle_y_min <= y <= middle_y_max:
-                    annotation["position"] = {"x": x, "y": y, "width": width, "height": height}
-                    annotations.append(annotation)
-    
-    # Ensure output directory exists
-    output_dir = os.path.dirname(output_json_path)
-    if output_dir:
-        os.makedirs(output_dir, exist_ok=True)
-    
-    with open(output_json_path, 'w') as f:
-        json.dump(annotations, f, indent=4)
-    
-    print(f"Annotations saved to {output_json_path}")
 
-# File paths
-xml_file = "slide2Pelvis.xml"
-output_json = "slide2_pelvis_annotations.json"
+                    slide_data["annotations"].append(annotation)
 
-# Run function with dynamic input
-parse_slide_xml(xml_file, output_json)
+    # Write JSON file for the slide
+    json_output_path = os.path.join(json_output, f"{slide_name}_annotations.json")
+    os.makedirs(json_output, exist_ok=True)
+
+    with open(json_output_path, 'w') as json_file:
+        json.dump(slide_data, json_file, indent=4)
+
+    print(f"[SUCCESS] JSON saved: {json_output_path}")
+
+
+def process_pptx_folders(slides_folder, rels_folder, media_folder, output_folder, json_output):
+    """
+    Processes all slides, extracts images, annotations, and writes JSON files.
+    """
+    os.makedirs(output_folder, exist_ok=True)
+    os.makedirs(json_output, exist_ok=True)
+
+    for slide_file in sorted(os.listdir(slides_folder)):
+        if slide_file.startswith("slide") and slide_file.endswith(".xml"):
+            slide_path = os.path.join(slides_folder, slide_file)
+            rels_path = os.path.join(rels_folder, slide_file + ".rels")
+
+            if os.path.exists(rels_path):
+                extract_images_from_slide_xml(slide_path, rels_path, media_folder, output_folder, json_output)
+            else:
+                print(f"[WARNING] Missing relationship file: {rels_path}. Skipping {slide_file}.")
+
+
+if __name__ == "__main__":
+    # Folder paths (replace with your paths)
+    slides_folder = "/Users/burhankhan/Desktop/ppt/slides"
+    rels_folder = "/Users/burhankhan/Desktop/ppt/slides/_rels"
+    media_folder = "/Users/burhankhan/Desktop/ppt/media"
+    output_folder = "/Users/burhankhan/Desktop/AutomatedScript"
+    json_output = "/Users/burhankhan/Desktop/AutomatedScript/json_output"
+
+    # Run the process for all slides
+    process_pptx_folders(slides_folder, rels_folder, media_folder, output_folder, json_output)


### PR DESCRIPTION
### Description

Fixes #86 

Changed the file name of the images being extracted to show clear location of where they are being pulled from (which slide, which reference number, etc.)

Ex:
image2.png --> slide1_rId8.png


# 1. What was Changed
The file, "AutomatedExtractionScript.py" was changed slightly to allow for proper title extraction. Most of the file remained the same. Improved success logging and error handling. 

# 2. Why it was Changed
To allow for clear image names instead of image1, image2, etc. Provides a better understanding of each image's relationship which will help when constructing the JSON.

# 3. How it was Changed 
By extracting the slidename specifically as well as the image extension. Considering the actual layout of the image in the PPTX and how it is saved. By saving them into a separate variable. Images are still grouped by slide and get their own respective folder.

# 4. Screenshots (if applicable)
<img width="902" alt="Screenshot 2025-02-17 at 2 29 39 PM" src="https://github.com/user-attachments/assets/3d0e13a7-6e2f-4a48-ad21-f238c010ce8f" />
