### PR TITLE
Implemented pop-up functionality for help modal.

### DIFF
--- a/boneset-api/package-lock.json
+++ b/boneset-api/package-lock.json
@@ -35,15 +35,17 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
-      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -109,6 +111,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -172,6 +175,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -261,6 +265,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.6",
@@ -366,13 +371,15 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -464,6 +471,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
       },

--- a/boneset-api/server.js
+++ b/boneset-api/server.js
@@ -96,7 +96,7 @@
 const express = require("express");
 const axios = require("axios");
 const cors = require("cors");
-const path = require('path');
+const path = require("path");
 
 const app = express();
 const PORT = process.env.PORT || 8000;
@@ -154,7 +154,7 @@ app.get("/combined-data", async (req, res) => {
 app.get("/api/description/", async (req, res) => { // Path changed here (no :boneId)
     const { boneId } = req.query; // Changed from req.params to req.query
     if (!boneId) {
-        return res.send(''); // Send empty response if no boneId is provided
+        return res.send(" "); // Send empty response if no boneId is provided
     }
     const GITHUB_DESC_URL = `https://raw.githubusercontent.com/oss-slu/DigitalBonesBox/data/DataPelvis/descriptions/${boneId}_description.json`;
 
@@ -169,7 +169,7 @@ app.get("/api/description/", async (req, res) => { // Path changed here (no :bon
         res.send(html);
 
     } catch (error) {
-        res.send('<li>Description not available.</li>');
+        res.send("<li>Description not available.</li>");
     }
 });
 

--- a/templates/boneset.html
+++ b/templates/boneset.html
@@ -79,6 +79,15 @@
     </div>
     <script type="module" src="js/main.js"></script>
 
+    <div id = "help-modal">
+        <div id = "help-modal-content">
+            <h2>How to Use</h2>
+            <p>
+                Use the dropfown menus to select a bonset, bone, or sub-bone. <br>
+                Once selected, you can view the image and description of the selected item. <br>
+            </p>
+            <button id = "close-help-modal">Close</button>
+    </div>
 </body>
 
 </html>

--- a/templates/boneset.html
+++ b/templates/boneset.html
@@ -16,7 +16,7 @@
         <span id="text-button-Home" role="button">Home</span>
         <span id="text-button-Tutor" role="button">Tutor</span>
         <span id="text-button-Study" role="button">Study</span>
-        <span id="text-button-Help" role="button">Help</span>
+        <div id="help-button-container"></div>
         <div id="innerbadge">
             <span id="text-button-Login" role="button">Login</span>
             <span id="text-button-SignUp" role="button">Sign Up</span>
@@ -78,16 +78,9 @@
             </div>
     </div>
     <script type="module" src="js/main.js"></script>
+    <script type="module" src="js/sidebar.js"></script>
 
-    <div id = "help-modal">
-        <div id = "help-modal-content">
-            <h2>How to Use</h2>
-            <p>
-                Use the dropfown menus to select a bonset, bone, or sub-bone. <br>
-                Once selected, you can view the image and description of the selected item. <br>
-            </p>
-            <button id = "close-help-modal">Close</button>
-    </div>
+    
 </body>
 
 </html>

--- a/templates/helpButton.html
+++ b/templates/helpButton.html
@@ -1,0 +1,43 @@
+<span 
+    id="text-button-Help" 
+    role="button"
+    tabindex="0"
+    aria-haspopup="dialog"
+    aria-controls="help-modal"
+>
+    Help
+</span>
+
+<div 
+    id="help-modal" 
+    class="help-modal" 
+    role="dialog"
+    aria-labelledby="help-modal-title"
+    aria-modal="true"
+    aria-hidden="true"
+>
+    <div 
+        id="help-modal-content" 
+        class="help-modal-content"
+        role="document"
+    >
+        <h2 id="help-modal-title">How to Use the Bone Set Viewer</h2>
+        <div class="help-content">
+            <ul>
+                <li>Use the dropdown menus to navigate through the bone sets</li>
+                <li>Select a boneset first, then choose specific bones</li>
+                <li>View detailed images and descriptions for each selection</li>
+                <li>Use the Previous/Next buttons to browse through items</li>
+                <li>Press ESC key or click Close to dismiss this help window</li>
+            </ul>
+            <button 
+                id="close-help-modal" 
+                type="button" 
+                class="btn"
+                aria-label="Close help modal"
+            >
+                Close Guide
+            </button>
+        </div>
+    </div>
+</div>

--- a/templates/js/api.js
+++ b/templates/js/api.js
@@ -1,7 +1,7 @@
 
 export async function fetchCombinedData() {
     // --- CORRECTED: Use the full URL of the backend server ---
-    const API_URL = 'http://127.0.0.1:8000/combined-data';
+    const API_URL = "http://127.0.0.1:8000/combined-data";
 
     try {
         const response = await fetch(API_URL);

--- a/templates/js/description.js
+++ b/templates/js/description.js
@@ -1,8 +1,8 @@
 // js/description.js
-const GITHUB_RAW_URL = 'https://raw.githubusercontent.com/oss-slu/DigitalBonesBox/data/DataPelvis/descriptions/';
+const GITHUB_RAW_URL = "https://raw.githubusercontent.com/oss-slu/DigitalBonesBox/data/DataPelvis/descriptions/";
 
 export async function loadDescription(id) {
-    const container = document.getElementById('description-Container');
+    const container = document.getElementById("description-Container");
     container.innerHTML = "";
     const descUrl = `${GITHUB_RAW_URL}${id}_description.json`;
 
@@ -10,12 +10,12 @@ export async function loadDescription(id) {
         const response = await fetch(descUrl);
         const data = await response.json();
 
-        const nameItem = document.createElement('li');
+        const nameItem = document.createElement("li");
         nameItem.innerHTML = `<strong>${data.name}</strong>`;
         container.appendChild(nameItem);
 
         data.description.forEach(point => {
-            const li = document.createElement('li');
+            const li = document.createElement("li");
             li.textContent = point;
             container.appendChild(li);
         });

--- a/templates/js/dropdowns.js
+++ b/templates/js/dropdowns.js
@@ -3,10 +3,9 @@ import { loadDescription } from "./description.js";
 
 export function populateBonesetDropdown(bonesets) {
     const bonesetSelect = document.getElementById("boneset-select");
-    bonesetSelect.innerHTML = '<option value="">--Please select a Boneset--</option>';
-
-    bonesets.forEach(set => {
-        const option = document.createElement('option');
+    bonesetSelect.innerHTML = "<option value=\"\">--Please select a Boneset--</option>"; 
+        bonesets.forEach(set => {
+        const option = document.createElement("option");
         option.value = set.id;
         option.textContent = set.name;
         bonesetSelect.appendChild(option);
@@ -14,20 +13,20 @@ export function populateBonesetDropdown(bonesets) {
 }
 
 export function setupDropdownListeners(combinedData) {
-    const bonesetSelect = document.getElementById('boneset-select');
-    const boneSelect = document.getElementById('bone-select');
-    const subboneSelect = document.getElementById('subbone-select');
+    const bonesetSelect = document.getElementById("boneset-select");
+    const boneSelect = document.getElementById("bone-select");
+    const subboneSelect = document.getElementById("subbone-select");
 
-    bonesetSelect.addEventListener('change', (e) => {
+    bonesetSelect.addEventListener("change", (e) => {
         const selectedBonesetId = e.target.value;
 
-        boneSelect.innerHTML = '<option value="">--Please select a Bone--</option>';
-        subboneSelect.innerHTML = '<option value="">--Please choose a Sub-Bone--</option>';
+        boneSelect.innerHTML = "<option value=\"\">--Please select a Bone--</option>";
+        subboneSelect.innerHTML = "<option value=\"\">--Please choose a Sub-Bone--</option>";
         subboneSelect.disabled = true;
 
         const relatedBones = combinedData.bones.filter(b => b.boneset === selectedBonesetId);
         relatedBones.forEach(bone => {
-            const option = document.createElement('option');
+            const option = document.createElement("option");
             option.value = bone.id;
             option.textContent = bone.name;
             boneSelect.appendChild(option);
@@ -37,13 +36,13 @@ export function setupDropdownListeners(combinedData) {
        // if (selectedBonesetId) loadDescription(selectedBonesetId);
     });
 
-    boneSelect.addEventListener('change', (e) => {
+    boneSelect.addEventListener("change", (e) => {
         const selectedBoneId = e.target.value;
 
-        subboneSelect.innerHTML = '<option value="">--Please choose a Sub-Bone--</option>';
+        subboneSelect.innerHTML = "<option value=\"\">--Please choose a Sub-Bone--</option>";
         const relatedSubbones = combinedData.subbones.filter(sb => sb.bone === selectedBoneId);
         relatedSubbones.forEach(sb => {
-            const option = document.createElement('option');
+            const option = document.createElement("option");
             option.value = sb.id;
             option.textContent = sb.name;
             subboneSelect.appendChild(option);
@@ -53,7 +52,7 @@ export function setupDropdownListeners(combinedData) {
         if (selectedBoneId) loadDescription(selectedBoneId);
     });
 
-    subboneSelect.addEventListener('change', (e) => {
+    subboneSelect.addEventListener("change", (e) => {
         const selectedSubboneId = e.target.value;
         if (selectedSubboneId) loadDescription(selectedSubboneId);
     });

--- a/templates/js/dropdowns.js
+++ b/templates/js/dropdowns.js
@@ -1,8 +1,8 @@
 // js/dropdowns.js
-import { loadDescription } from './description.js';
+import { loadDescription } from "./description.js";
 
 export function populateBonesetDropdown(bonesets) {
-    const bonesetSelect = document.getElementById('boneset-select');
+    const bonesetSelect = document.getElementById("boneset-select");
     bonesetSelect.innerHTML = '<option value="">--Please select a Boneset--</option>';
 
     bonesets.forEach(set => {

--- a/templates/js/main.js
+++ b/templates/js/main.js
@@ -1,12 +1,12 @@
-import { fetchCombinedData } from './api.js';
-import { populateBonesetDropdown, setupDropdownListeners } from './dropdowns.js';
-import { initializeSidebar } from './sidebar.js';
-import { setupNavigation, setBoneAndSubbones, disableButtons } from './navigation.js';
-import { loadDescription } from './description.js'; // ✅ CORRECT function name
+import { fetchCombinedData } from "./api.js";
+import { populateBonesetDropdown, setupDropdownListeners } from "./dropdowns.js";
+import { initializeSidebar } from "./sidebar.js";
+import { setupNavigation, setBoneAndSubbones, disableButtons } from "./navigation.js";
+import { loadDescription } from "./description.js"; // ✅ CORRECT function name
 
 let combinedData = { bonesets: [], bones: [], subbones: [] };
 
-document.addEventListener('DOMContentLoaded', async () => {
+document.addEventListener("DOMContentLoaded", async () => {
     // 1. Sidebar behavior
     initializeSidebar();
 
@@ -16,15 +16,15 @@ document.addEventListener('DOMContentLoaded', async () => {
     setupDropdownListeners(combinedData);
 
     // 3. Hook up navigation buttons
-    const prevButton = document.getElementById('prev-button');
-    const nextButton = document.getElementById('next-button');
-    const subboneDropdown = document.getElementById('subbone-select');
-    const boneDropdown = document.getElementById('bone-select');
+    const prevButton = document.getElementById("prev-button");
+    const nextButton = document.getElementById("next-button");
+    const subboneDropdown = document.getElementById("subbone-select");
+    const boneDropdown = document.getElementById("bone-select");
 
     setupNavigation(prevButton, nextButton, subboneDropdown, loadDescription);
 
     // 4. Update navigation when bone changes
-    boneDropdown.addEventListener('change', (event) => {
+    boneDropdown.addEventListener("change", (event) => {
         const selectedBone = event.target.value;
 
         const relatedSubbones = combinedData.subbones
@@ -39,18 +39,18 @@ document.addEventListener('DOMContentLoaded', async () => {
     // 5. Auto-select the first boneset
     const boneset = combinedData.bonesets[0];
     if (boneset) {
-        document.getElementById('boneset-select').value = boneset.id;
-        const event = new Event('change');
-        document.getElementById('boneset-select').dispatchEvent(event);
+        document.getElementById("boneset-select").value = boneset.id;
+        const event = new Event("change");
+        document.getElementById("boneset-select").dispatchEvent(event);
     }
 });
 
 function populateSubboneDropdown(dropdown, subbones) {
-    dropdown.innerHTML = '';
+    dropdown.innerHTML = "";
     subbones.forEach((subboneId) => {
-        const option = document.createElement('option');
+        const option = document.createElement("option");
         option.value = subboneId;
-        option.textContent = subboneId.replace(/_/g, ' ');
+        option.textContent = subboneId.replace(/_/g, " ");
         dropdown.appendChild(option);
     });
 }

--- a/templates/js/navigation.js
+++ b/templates/js/navigation.js
@@ -3,12 +3,12 @@ let currentSubboneIndex = -1;
 let subbones = [];
 
 export function setupNavigation(prevButton, nextButton, subboneDropdown, updateDescription) {
-  prevButton.addEventListener('click', () => {
+  prevButton.addEventListener("click", () => {
     prevSubbone();
     updateUI(subboneDropdown, updateDescription);
   });
 
-  nextButton.addEventListener('click', () => {
+  nextButton.addEventListener("click", () => {
     nextSubbone();
     updateUI(subboneDropdown, updateDescription);
   });

--- a/templates/js/sidebar.js
+++ b/templates/js/sidebar.js
@@ -1,30 +1,30 @@
 // js/sidebar.js
 export function initializeSidebar() {
-    const toggleButton = document.getElementById('toggle-sidebar');
-    const sidebarContainer = document.getElementById('sidebar-container');
+    const toggleButton = document.getElementById("toggle-sidebar");
+    const sidebarContainer = document.getElementById("sidebar-container");
 
     async function loadSidebar() {
         if (!sidebarContainer.innerHTML) {
             try {
-                const response = await fetch('sidebar.html');
+                const response = await fetch("sidebar.html");
                 const sidebarHTML = await response.text();
                 sidebarContainer.innerHTML = sidebarHTML;
             } catch (error) {
-                console.error('Error loading sidebar:', error);
+                console.error("Error loading sidebar:", error);
             }
         }
     }
 
     if (toggleButton) {
-        toggleButton.addEventListener('click', async () => {
+        toggleButton.addEventListener("click", async () => {
             await loadSidebar(); // Ensure the sidebar is loaded
-            const sidebarElement = document.getElementById('sidebar');
+            const sidebarElement = document.getElementById("sidebar");
 
             if (sidebarElement) {
-                if (sidebarElement.style.left === '0px') {
-                    sidebarElement.style.left = '-250px'; // Close sidebar
+                if (sidebarElement.style.left === "0px") {
+                    sidebarElement.style.left = "-250px"; // Close sidebar
                 } else {
-                    sidebarElement.style.left = '0px'; // Open sidebar
+                    sidebarElement.style.left = "0px"; // Open sidebar
                 }
             }
         });
@@ -32,49 +32,49 @@ export function initializeSidebar() {
 }
 
 export async function loadHelpButton() {
-    const helpButtonContainer = document.getElementById('help-button-container');
+    const helpButtonContainer = document.getElementById("help-button-container");
     if (helpButtonContainer) {
         try {
-            const response = await fetch('helpButton.html');
+            const response = await fetch("helpButton.html");
             const helpButtonHTML = await response.text();
             helpButtonContainer.innerHTML = helpButtonHTML;
             
-            const helpButton = document.getElementById('text-button-Help');
-            const helpModal = document.getElementById('help-modal');
-            const closeHelpModal = document.getElementById('close-help-modal');
+            const helpButton = document.getElementById("text-button-Help");
+            const helpModal = document.getElementById("help-modal");
+            const closeHelpModal = document.getElementById("close-help-modal");
             
             if (helpButton && helpModal && closeHelpModal) {
                 // Handle click events
-                helpButton.addEventListener('click', () => {
-                    helpModal.classList.add('is-visible');
+                helpButton.addEventListener("click", () => {
+                    helpModal.classList.add("is-visible");
                 });
                 
-                closeHelpModal.addEventListener('click', () => {
-                    helpModal.classList.remove('is-visible');
+                closeHelpModal.addEventListener("click", () => {
+                    helpModal.classList.remove("is-visible");
                 });
                 
                 // Handle keyboard events
-                helpButton.addEventListener('keydown', (event) => {
-                    if (event.key === 'Enter' || event.key === ' ') {
+                helpButton.addEventListener("keydown", (event) => {
+                    if (event.key === "Enter" || event.key === " ") {
                         event.preventDefault();
-                        helpModal.classList.add('is-visible');
+                        helpModal.classList.add("is-visible");
                     }
                 });
                 
                 // Close on escape key
-                document.addEventListener('keydown', (event) => {
-                    if (event.key === 'Escape' && helpModal.classList.contains('is-visible')) {
-                        helpModal.classList.remove('is-visible');
+                document.addEventListener("keydown", (event) => {
+                    if (event.key === "Escape" && helpModal.classList.contains("is-visible")) {
+                        helpModal.classList.remove("is-visible");
                     }
                 });
             }
         } catch (error) {
-            console.error('Error loading help button:', error);
+            console.error("Error loading help button:", error);
         }
     }
 }
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener("DOMContentLoaded", () => {
     initializeSidebar();
     loadHelpButton();
 });

--- a/templates/js/sidebar.js
+++ b/templates/js/sidebar.js
@@ -30,17 +30,52 @@ export function initializeSidebar() {
         });
     }
 }
-document.addEventListener('DOMContentLoaded', () => {
-    const helpButton = document.getElementById('text-button-Help');
-    const helpModal = document.getElementById('help-modal');
-    const closeHelpModal = document.getElementById('close-help-modal');
-    if (helpButton && helpModal && closeHelpModal) {
-        helpButton.addEventListener('click', () => {
-            helpModal.style.display = 'flex';
-        });
-        closeHelpModal.addEventListener('click', () => {
-            helpModal.style.display = 'none';
-        });
+
+export async function loadHelpButton() {
+    const helpButtonContainer = document.getElementById('help-button-container');
+    if (helpButtonContainer) {
+        try {
+            const response = await fetch('helpButton.html');
+            const helpButtonHTML = await response.text();
+            helpButtonContainer.innerHTML = helpButtonHTML;
+            
+            const helpButton = document.getElementById('text-button-Help');
+            const helpModal = document.getElementById('help-modal');
+            const closeHelpModal = document.getElementById('close-help-modal');
+            
+            if (helpButton && helpModal && closeHelpModal) {
+                // Handle click events
+                helpButton.addEventListener('click', () => {
+                    helpModal.classList.add('is-visible');
+                });
+                
+                closeHelpModal.addEventListener('click', () => {
+                    helpModal.classList.remove('is-visible');
+                });
+                
+                // Handle keyboard events
+                helpButton.addEventListener('keydown', (event) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault();
+                        helpModal.classList.add('is-visible');
+                    }
+                });
+                
+                // Close on escape key
+                document.addEventListener('keydown', (event) => {
+                    if (event.key === 'Escape' && helpModal.classList.contains('is-visible')) {
+                        helpModal.classList.remove('is-visible');
+                    }
+                });
+            }
+        } catch (error) {
+            console.error('Error loading help button:', error);
+        }
     }
-})
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    initializeSidebar();
+    loadHelpButton();
+});
 

--- a/templates/js/sidebar.js
+++ b/templates/js/sidebar.js
@@ -30,3 +30,17 @@ export function initializeSidebar() {
         });
     }
 }
+document.addEventListener('DOMContentLoaded', () => {
+    const helpButton = document.getElementById('text-button-Help');
+    const helpModal = document.getElementById('help-modal');
+    const closeHelpModal = document.getElementById('close-help-modal');
+    if (helpButton && helpModal && closeHelpModal) {
+        helpButton.addEventListener('click', () => {
+            helpModal.style.display = 'flex';
+        });
+        closeHelpModal.addEventListener('click', () => {
+            helpModal.style.display = 'none';
+        });
+    }
+})
+

--- a/templates/style.css
+++ b/templates/style.css
@@ -201,3 +201,40 @@ ul li {
     pointer-events: none; /* So clicks pass through to the image */
 }
 
+#help-modal {
+    display: none; 
+    position: fixed; 
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background: rgba(0, 0, 0, 0.4);
+    z-index: 2000;
+    justify-content: center;
+    align-items: center;
+}
+
+#help-modal-context {
+    background: #fff;
+    padding: 2em 1.5em;
+    border-radius: 10px;
+    max-width: 400px;
+    margin: auto;
+    box-shadow: 0 4px 24px rgba(0, 0, 0, 0.2);
+    text-align: center;
+    position: relative;
+}
+
+#close-help-modal {
+    margin-top: 1em;
+    padding: 8px 20px; 
+    background-color: #007bff;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+#close-help-modal:hover {
+    background-color: #0056b3;
+}

--- a/templates/style.css
+++ b/templates/style.css
@@ -201,40 +201,107 @@ ul li {
     pointer-events: none; /* So clicks pass through to the image */
 }
 
-#help-modal {
-    display: none; 
-    position: fixed; 
+.help-modal {
+    position: fixed;
     top: 0;
     left: 0;
     width: 100vw;
     height: 100vh;
-    background: rgba(0, 0, 0, 0.4);
-    z-index: 2000;
+    background: rgba(0, 0, 0, 0.85);
+    display: none;
+    z-index: 1000;
     justify-content: center;
     align-items: center;
+    padding: 1.5rem;
+    backdrop-filter: blur(4px);
+    transition: opacity 0.3s ease;
 }
 
-#help-modal-context {
-    background: #fff;
-    padding: 2em 1.5em;
-    border-radius: 10px;
-    max-width: 400px;
-    margin: auto;
-    box-shadow: 0 4px 24px rgba(0, 0, 0, 0.2);
-    text-align: center;
-    position: relative;
+.help-modal.is-visible {
+    display: flex;
+    animation: modalFadeIn 0.3s ease;
+}
+
+.help-modal-content {
+    background: linear-gradient(to bottom, #ffffff, #f8f9fa);
+    padding: 1rem;
+    border-radius: 12px;
+    width: 90%;
+    max-width: 500px;
+    max-height: 85vh;
+    overflow-y: auto;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+}
+
+#help-modal-title {
+    color: #1a4b8c;
+    font-size: 1.4rem;
+    margin-bottom: 0.5rem;
+    border-bottom: 2px solid #e9ecef;
+    padding-bottom: 0.5rem;
+}
+
+.help-content {
+    padding: 0;
+}
+
+.help-content p {
+    margin-bottom: 0.75rem;
+    line-height: 1.4;
+    color: #1a4b8c;
+}
+
+.help-content ul {
+    margin: 0;
+    padding-left: 1rem;
+}
+
+.help-content li {
+    color: #1a4b8c;
+    margin-bottom: 0.4rem;
+    line-height: 1.3;
 }
 
 #close-help-modal {
-    margin-top: 1em;
-    padding: 8px 20px; 
-    background-color: #007bff;
-    color: #fff;
-    border: none;
-    border-radius: 4px;
-    cursor: pointer;
+    margin-top: 1rem;
+    padding: 0.5rem 1.25rem;
+    width: auto;
+    min-width: 120px;
 }
 
 #close-help-modal:hover {
-    background-color: #0056b3;
+    background-color: #0d2d5e;
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(26, 75, 140, 0.2);
+}
+
+#close-help-modal:focus {
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(26, 75, 140, 0.4);
+}
+
+@keyframes modalFadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+@keyframes modalSlideUp {
+    from { 
+        transform: translateY(20px);
+        opacity: 0;
+    }
+    to { 
+        transform: translateY(0);
+        opacity: 1;
+    }
+}
+
+/* High contrast mode support */
+@media (forced-colors: active) {
+    .help-modal-content {
+        border: 2px solid CanvasText;
+    }
+    #close-help-modal {
+        border: 2px solid CanvasText;
+    }
 }

--- a/templates/test.js
+++ b/templates/test.js
@@ -9,7 +9,7 @@ const html = `
 `;
 document.body.innerHTML = html;
 
-require('./sidebar.js'); // Import the JavaScript code
+require("./sidebar.js"); // Import the JavaScript code
 
 beforeEach(() => {
     global.fetch = jest.fn(() =>
@@ -23,90 +23,90 @@ beforeEach(() => {
         })
     );
 
-    const sidebarContainer = document.getElementById('sidebar-container');
-    sidebarContainer.innerHTML = ''; // Reset sidebar container
+    const sidebarContainer = document.getElementById("sidebar-container");
+    sidebarContainer.innerHTML = ""; // Reset sidebar container
 
-    const sidebarElement = document.getElementById('sidebar');
+    const sidebarElement = document.getElementById("sidebar");
     if (sidebarElement) {
-        sidebarElement.style.left = '-250px'; // Explicitly set the initial state
+        sidebarElement.style.left = "-250px"; // Explicitly set the initial state
     }
 });
 
 beforeAll(() => {
-    document.dispatchEvent(new Event('DOMContentLoaded')); // Simulate DOMContentLoaded
+    document.dispatchEvent(new Event("DOMContentLoaded")); // Simulate DOMContentLoaded
 });
 
 afterEach(() => {
     // Reset sidebar state after each test
-    const sidebarElement = document.getElementById('sidebar');
+    const sidebarElement = document.getElementById("sidebar");
     if (sidebarElement) {
-        sidebarElement.style.left = '-250px'; // Ensure sidebar is closed
+        sidebarElement.style.left = "-250px"; // Ensure sidebar is closed
     }
     jest.restoreAllMocks(); // Clean up mocks
 });
 
-describe('Sidebar Toggle Functionality', () => {
-    test('loads sidebar content when the button is clicked', async () => {
-        const toggleButton = document.getElementById('toggle-sidebar');
+describe("Sidebar Toggle Functionality", () => {
+    test("loads sidebar content when the button is clicked", async () => {
+        const toggleButton = document.getElementById("toggle-sidebar");
         toggleButton.click();
         await new Promise(process.nextTick);
 
-        const sidebarElement = document.getElementById('sidebar');
+        const sidebarElement = document.getElementById("sidebar");
         expect(sidebarElement).toBeTruthy();
-        expect(sidebarElement.innerHTML).toContain('Sidebar Content');
+        expect(sidebarElement.innerHTML).toContain("Sidebar Content");
     });
 
-    test('toggles sidebar open and closed', async () => {
-        const toggleButton = document.getElementById('toggle-sidebar');
-        const sidebarElement = document.getElementById('sidebar');
+    test("toggles sidebar open and closed", async () => {
+        const toggleButton = document.getElementById("toggle-sidebar");
+        const sidebarElement = document.getElementById("sidebar");
 
         // Ensure the sidebar starts hidden
         let computedStyle = window.getComputedStyle(sidebarElement);
-        expect(computedStyle.left).toBe('-250px'); // Sidebar is initially hidden
+        expect(computedStyle.left).toBe("-250px"); // Sidebar is initially hidden
 
         // Simulate opening the sidebar
         toggleButton.click();
         await new Promise((resolve) => setTimeout(resolve, 50)); // Wait for event propagation
         computedStyle = window.getComputedStyle(sidebarElement);
-        expect(computedStyle.left).toBe('0px'); // Sidebar is open
+        expect(computedStyle.left).toBe("0px"); // Sidebar is open
 
         // Simulate closing the sidebar
         toggleButton.click();
         await new Promise((resolve) => setTimeout(resolve, 50)); // Wait for event propagation
         computedStyle = window.getComputedStyle(sidebarElement);
-        expect(computedStyle.left).toBe('-250px'); // Sidebar is closed
+        expect(computedStyle.left).toBe("-250px"); // Sidebar is closed
     });
 });
 
-describe('Badge Button', () => {
-    test('badge button is present and clickable', () => {
-        const badgeButton = document.getElementById('toggle-sidebar');
+describe("Badge Button", () => {
+    test("badge button is present and clickable", () => {
+        const badgeButton = document.getElementById("toggle-sidebar");
         expect(badgeButton).toBeTruthy();
-        expect(badgeButton.tagName).toBe('BUTTON');
+        expect(badgeButton.tagName).toBe("BUTTON");
     });
 
-    test('badge button has correct initial text', () => {
-        const badgeButton = document.getElementById('toggle-sidebar');
-        expect(badgeButton.textContent).toBe('☰');
+    test("badge button has correct initial text", () => {
+        const badgeButton = document.getElementById("toggle-sidebar");
+        expect(badgeButton.textContent).toBe("☰");
     });
 });
 
-describe('Sidebar Styling', () => {
-    test('sidebar starts hidden by default', () => {
-        const sidebar = document.getElementById('sidebar');
+describe("Sidebar Styling", () => {
+    test("sidebar starts hidden by default", () => {
+        const sidebar = document.getElementById("sidebar");
         expect(sidebar).toBeTruthy();
 
         const computedStyle = window.getComputedStyle(sidebar);
-        expect(computedStyle.left).toBe('-250px'); // Sidebar is hidden initially
+        expect(computedStyle.left).toBe("-250px"); // Sidebar is hidden initially
     });
 
-    test('sidebar transitions smoothly', () => {
-        const sidebar = document.getElementById('sidebar');
-        expect(sidebar.style.transition).toContain('left 0.3s ease');
+    test("sidebar transitions smoothly", () => {
+        const sidebar = document.getElementById("sidebar");
+        expect(sidebar.style.transition).toContain("left 0.3s ease");
     });
 });
 
-describe('Help Modal Functionality', () => {
+describe("Help Modal Functionality", () => {
     beforeEach(() => {
         // Add help button and modal HTML to the test environment
         document.body.innerHTML += `
@@ -119,45 +119,45 @@ describe('Help Modal Functionality', () => {
         `;
     });
 
-    test('modal is hidden by default', () => {
-        const helpModal = document.getElementById('help-modal');
-        expect(helpModal.classList.contains('is-visible')).toBeFalsy();
+    test("modal is hidden by default", () => {
+        const helpModal = document.getElementById("help-modal");
+        expect(helpModal.classList.contains("is-visible")).toBeFalsy();
         const computedStyle = window.getComputedStyle(helpModal);
-        expect(computedStyle.display).not.toBe('flex');
+        expect(computedStyle.display).not.toBe("flex");
     });
 
-    test('modal becomes visible when Help button is clicked', () => {
-        const helpButton = document.getElementById('text-button-Help');
-        const helpModal = document.getElementById('help-modal');
+    test("modal becomes visible when Help button is clicked", () => {
+        const helpButton = document.getElementById("text-button-Help");
+        const helpModal = document.getElementById("help-modal");
         
         helpButton.click();
         
-        expect(helpModal.classList.contains('is-visible')).toBeTruthy();
+        expect(helpModal.classList.contains("is-visible")).toBeTruthy();
     });
 
-    test('modal becomes hidden when Close button is clicked', () => {
-        const helpModal = document.getElementById('help-modal');
-        const closeButton = document.getElementById('close-help-modal');
+    test("modal becomes hidden when Close button is clicked", () => {
+        const helpModal = document.getElementById("help-modal");
+        const closeButton = document.getElementById("close-help-modal");
         
         // First make modal visible
-        helpModal.classList.add('is-visible');
+        helpModal.classList.add("is-visible");
         
         // Then click close button
         closeButton.click();
         
-        expect(helpModal.classList.contains('is-visible')).toBeFalsy();
+        expect(helpModal.classList.contains("is-visible")).toBeFalsy();
     });
 
-    test('modal closes when Escape key is pressed', () => {
-        const helpModal = document.getElementById('help-modal');
+    test("modal closes when Escape key is pressed", () => {
+        const helpModal = document.getElementById("help-modal");
         
         // First make modal visible
-        helpModal.classList.add('is-visible');
+        helpModal.classList.add("is-visible");
         
         // Simulate pressing Escape key
-        const escapeKeyEvent = new KeyboardEvent('keydown', { key: 'Escape' });
+        const escapeKeyEvent = new KeyboardEvent("keydown", { key: "Escape" });
         document.dispatchEvent(escapeKeyEvent);
         
-        expect(helpModal.classList.contains('is-visible')).toBeFalsy();
+        expect(helpModal.classList.contains("is-visible")).toBeFalsy();
     });
 });

--- a/templates/test.js
+++ b/templates/test.js
@@ -105,3 +105,59 @@ describe('Sidebar Styling', () => {
         expect(sidebar.style.transition).toContain('left 0.3s ease');
     });
 });
+
+describe('Help Modal Functionality', () => {
+    beforeEach(() => {
+        // Add help button and modal HTML to the test environment
+        document.body.innerHTML += `
+            <span id="text-button-Help" role="button">Help</span>
+            <div id="help-modal" class="help-modal">
+                <div id="help-modal-content">
+                    <button id="close-help-modal">Close Guide</button>
+                </div>
+            </div>
+        `;
+    });
+
+    test('modal is hidden by default', () => {
+        const helpModal = document.getElementById('help-modal');
+        expect(helpModal.classList.contains('is-visible')).toBeFalsy();
+        const computedStyle = window.getComputedStyle(helpModal);
+        expect(computedStyle.display).not.toBe('flex');
+    });
+
+    test('modal becomes visible when Help button is clicked', () => {
+        const helpButton = document.getElementById('text-button-Help');
+        const helpModal = document.getElementById('help-modal');
+        
+        helpButton.click();
+        
+        expect(helpModal.classList.contains('is-visible')).toBeTruthy();
+    });
+
+    test('modal becomes hidden when Close button is clicked', () => {
+        const helpModal = document.getElementById('help-modal');
+        const closeButton = document.getElementById('close-help-modal');
+        
+        // First make modal visible
+        helpModal.classList.add('is-visible');
+        
+        // Then click close button
+        closeButton.click();
+        
+        expect(helpModal.classList.contains('is-visible')).toBeFalsy();
+    });
+
+    test('modal closes when Escape key is pressed', () => {
+        const helpModal = document.getElementById('help-modal');
+        
+        // First make modal visible
+        helpModal.classList.add('is-visible');
+        
+        // Simulate pressing Escape key
+        const escapeKeyEvent = new KeyboardEvent('keydown', { key: 'Escape' });
+        document.dispatchEvent(escapeKeyEvent);
+        
+        expect(helpModal.classList.contains('is-visible')).toBeFalsy();
+    });
+});


### PR DESCRIPTION
### Description

Fixes #121 

# 1. What was Changed
A user-friendly help modal was added to the application. When users click the "Help" button on the sidebar, a pop-up modal appears with instructions on how to use the bone set viewer. The modal includes a title, a brief description, and a close button. 

# 2. Why it was Changed
The goal was to get a basic help button design down before making any complex changes. This change was needed to improve the application's usability and accessibility. Previously, the "Help" link was non-functional, which is not beneficial for end-users. By providing clear instructions in a modal, users can quickly understand how to interact with the interface. 

# 3. How it was Changed 
There was no operating help modal before this pull request. The basic modal is hidden by default and is displayed using a flex overlay when the "Help" link is clicked. The close button hides the modal. 
