### PR TITLE
Add installation of backend dependencies in lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Install backend dependencies
+        run: npm install --prefix boneset-api
+
       - name: Run ESLint
         run: npm run lint
 


### PR DESCRIPTION
Added step to install backend dependencies for the project. Necessary because dependencies only in the `boneset-api/` directory were not being installed, causing tests not to run.
