### PR TITLE
Apply colored region to quiz images

### DIFF
--- a/templates/js/quiz.js
+++ b/templates/js/quiz.js
@@ -1,6 +1,7 @@
 // quiz.js - Quiz functionality for Digital Bones Box
 
 import {fetchBoneData, fetchCombinedData} from "./api.js";
+import {displayColoredRegions} from "./coloredRegionsOverlay.js";
 
 class QuizManager {
     constructor() {
@@ -170,29 +171,8 @@ async fetchBoneImage(itemId, container) {
         
         // Check if image exists in the response
         if (data.images && data.images.length > 0) {
-            // SMART LOGIC: Prefer annotated images over plain images
-            let imageUrl;
-            
-            // Try to find an annotated image (colored regions)
-            const annotatedImage = data.images.find(img => 
-                img.filename && (
-                    img.filename.toLowerCase().includes("annotated") ||
-                    img.filename.toLowerCase().includes("annotation") ||
-                    img.filename.toLowerCase().includes("colored")
-                )
-            );
-            
-            if (annotatedImage) {
-                // Use annotated image if available
-                imageUrl = annotatedImage.url;
-                console.log(`✓ Using ANNOTATED image for ${itemId}:`, imageUrl);
-            } else {
-                // Fall back to first image if no annotated version exists yet
-                imageUrl = data.images[0].url;
-                console.log(`Using plain image for ${itemId} (annotated not available yet):`, imageUrl);
-            }
-            
             // Create image element with error handling
+            let imageUrl = data.images[0].url;
             const img = document.createElement("img");
             img.src = imageUrl;
             img.alt = itemId;
@@ -213,6 +193,9 @@ async fetchBoneImage(itemId, container) {
             };
             
             img.onload = () => {
+                displayColoredRegions(img, itemId, 0).catch(err => {
+                    console.warn(`Could not display colored regions for ${itemId}:`, err);
+                });
                 console.log(`Image loaded successfully for ${itemId}`);
             };
             


### PR DESCRIPTION
## Pull Request Summary

Closes #306 <!-- Add the issue number here -->

*A brief description/summary of your PR here. **What** does it add? **Why** is it necessary? **How** was the change made, and how was it tested?*

The quiz code uses the correct logic to apply colored region annotations onto images. The annotations may appear in slightly the wrong place, but this is a bug in the main viewing interface too (when resizing the images and browser window) and should be addressed in another issue.

## Screenshots

*If applicable, add screenshots showing the before and after of any UI changes made.*

<img width="1637" height="1547" alt="image" src="https://github.com/user-attachments/assets/be86751d-a181-4479-ae39-6447f42cfcac" />

## PR Checklist

- [X] Project builds and runs
- [X] Tests and linters pass
- [X] Any related documentation has been updated, including JSDoc comments or docstrings

## Detailed Description

*A more detailed description and any additional information.*
