### PR TITLE
Potential fix for code scanning alert no. 12: DOM text reinterpreted as HTML

### DIFF
--- a/templates/diagnostic-colored-regions.html
+++ b/templates/diagnostic-colored-regions.html
@@ -110,6 +110,18 @@
 
         window.diagnosticLog = [];
 
+        function escapeHtml(str) {
+            if (str === null || str === undefined) {
+                return '';
+            }
+            return String(str)
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;');
+        }
+
         function addLog(type, message, data = null) {
             const timestamp = new Date().toLocaleTimeString();
             const logEntry = { timestamp, type, message, data };
@@ -118,9 +130,11 @@
             const output = document.getElementById('diagnosticOutput');
             const className = type === 'error' ? 'error' : type === 'success' ? 'success' : type === 'warning' ? 'warning' : 'info';
             
-            let html = `<div class="status ${className}"><strong>[${timestamp}] ${type.toUpperCase()}:</strong> ${message}`;
+            const safeMessage = escapeHtml(message);
+            let html = `<div class="status ${className}"><strong>[${timestamp}] ${type.toUpperCase()}:</strong> ${safeMessage}`;
             if (data) {
-                html += `<pre>${JSON.stringify(data, null, 2)}</pre>`;
+                const safeData = escapeHtml(JSON.stringify(data, null, 2));
+                html += `<pre>${safeData}</pre>`;
             }
             html += '</div>';
             
@@ -260,7 +274,7 @@
                 resultsDiv.innerHTML = `
                     <div class="status error">
                         <strong>❌ Error Creating SVG</strong><br>
-                        ${error.message}
+                        ${escapeHtml(error.message)}
                     </div>
                 `;
             }


### PR DESCRIPTION
Potential fix for [https://github.com/oss-slu/DigitalBonesBox/security/code-scanning/12](https://github.com/oss-slu/DigitalBonesBox/security/code-scanning/12)

In general, the problem is that untrusted text (`message`) is interpolated into an HTML string that is assigned to `innerHTML`. To fix this, any untrusted text must be properly escaped (so it is treated as text, not markup), or inserted into the DOM using APIs that do not interpret it as HTML (e.g., `textContent`, `createTextNode`). We should retain the existing visual structure (the `<div class="status ..."><strong>…</strong> …</div>` layout and the JSON `<pre>`) but ensure that attacker-controlled values cannot inject HTML.

The single best fix with minimal functional change is to (1) add a small client-side HTML-escaping helper, and (2) use it when inserting `message`, JSON data, and any other potentially untrusted values into strings that go into `innerHTML`. For `addLog`, we can still build `html` as a string, but we must run `message` and `JSON.stringify(data)` through an `escapeHtml` function before interpolating. Likewise, in the `resultsDiv.innerHTML` blocks that insert `error.message`, we should escape `error.message` before including it. The `className` and other static text can remain unchanged, as they are either hardcoded or derived from controlled sources. Concretely:

- Add a small `escapeHtml(str)` helper at the top of the `<script type="module">` block.
- Update `addLog` so that:
  - `message` is replaced with `escapeHtml(message)`.
  - If `data` is present, the `<pre>` content is `escapeHtml(JSON.stringify(data, null, 2))`.
- Update the error-handling block around line 258 so that `${error.message}` is replaced with `${escapeHtml(error.message)}`.
- Other uses of template literals that only include numbers or known-safe values (like `paths.length`, `svg.getAttribute('width')`, etc.) can remain unchanged, as CodeQL’s taint trace only implicated the logging path.

This preserves existing functionality and appearance while ensuring DOM text is not reinterpreted as HTML.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
