### PR TITLE
Issue 307

### DIFF
--- a/templates/js/quiz.js
+++ b/templates/js/quiz.js
@@ -175,7 +175,7 @@ async fetchBoneImage(itemId, container) {
             let imageUrl = data.images[0].url;
             const img = document.createElement("img");
             img.src = imageUrl;
-            img.alt = itemId;
+            img.alt = "Bone image for quiz question";
             img.style.maxWidth = "100%";
             img.style.maxHeight = "400px";
             img.style.objectFit = "contain";


### PR DESCRIPTION
## Pull Request Summary

Closes #307 

The alt text for quiz images has been changed from the bone ID to "Bone image for quiz question" to avoid giving away the answer for screen readers.