### PR TITLE
fix: add a continue statement in searchItems function

### DIFF
--- a/boneset-api/server.js
+++ b/boneset-api/server.js
@@ -136,6 +136,8 @@ function searchItems(query, limit = 20) {
     
     // First pass: prefix matches (higher priority)
     for (const item of searchCache) {
+        if (!item.name) continue;
+        
         if (item.name.toLowerCase().startsWith(q)) {
             results.push({ ...item, priority: 1 });
         }
@@ -143,6 +145,8 @@ function searchItems(query, limit = 20) {
     
     // Second pass: substring matches (lower priority)
     for (const item of searchCache) {
+        if (!item.name) continue;
+        
         if (!item.name.toLowerCase().startsWith(q) && item.name.toLowerCase().includes(q)) {
             results.push({ ...item, priority: 2 });
         }


### PR DESCRIPTION
## Pull Request Summary

Closes #365 

Fixes a bug where the search endpoint crashes if a bone or boneset JSON file from the data repository is missing the `name` property. By adding `if (!item.name) continue;` now the search works as expected.

## PR Checklist

- [x] Project builds and runs
- [x] Tests and linters pass
- [ ] Any related documentation has been updated, including JSDoc comments or docstrings


