### PR TITLE
fix: add visual feedback for keyboard navigation in search

### DIFF
--- a/templates/js/search.js
+++ b/templates/js/search.js
@@ -1,8 +1,10 @@
 let selectedIndex = -1;
 let searchTimeout;
+let isInitialized = false;
 
 // Handle search result clicks and keyboard navigation
 export function initializeSearch() {
+    if (isInitialized) return;
     const searchBar = document.getElementById("search-bar");
     const searchResultsContainer = document.getElementById("search-results");
     const searchLoading = document.getElementById("search-loading");
@@ -13,7 +15,8 @@ export function initializeSearch() {
     }
 
     console.log("Search initialized");
-
+    isInitialized = true;
+    
     // Handle typing in search bar
     searchBar.addEventListener("input", (e) => {
         clearTimeout(searchTimeout);

--- a/templates/style.css
+++ b/templates/style.css
@@ -1247,14 +1247,16 @@ button:disabled {
     transition: width var(--transition-normal);
 }
 
-#search-results li:hover {
+#search-results li:hover,
+#search-results li.selected {
     background: var(--primary-light);
     transform: translateX(12px);
     color: var(--primary);
     font-weight: 600;
 }
 
-#search-results li:hover::before {
+#search-results li:hover::before,
+#search-results li.selected::before {
     width: 4px;
 }
 


### PR DESCRIPTION
## Pull Request Summary

Closes #354

This PR fixes two related issues with the search bar's keyboard navigation:

* It adds the missing visual feedback when navigating search results using the arrow up/down keys.
* it fixes a "skip by two" bug when navigating search results using the arrow up/down keys. Let's say, for example, your search returned 6 results. Only search items number 2, 4 and 6 could be selected by using the arrow down/up keys. Of course, the expected behavior should be go down or up one by one.

The search logic was being initialized twice: once via a DOMContentLoaded event listener inside ``search.js``, and again when explicitly imported and called by ``main.js``. This caused the keydown event listener to attach twice, leading to the "skip-by-two" behavior.

changes:

``style.css``: Appended the .selected class to the existing #search-results li:hover CSS rules. This maps the JavaScript keyboard selection directly to the existing mouse-hover visual states

``search.js``: Added an isInitialized flag at the top of the initializeSearch function to return early if it has already run. This locks the function after its first execution, preventing duplicate event listeners.

## Video


https://github.com/user-attachments/assets/0fc1bf18-ac3b-4c04-a301-5b6449c333ba



## PR Checklist

- [x] Project builds and runs
- [x] Tests and linters pass
- [ ] Any related documentation has been updated, including JSDoc comments or docstrings

## Detailed Description

*A more detailed description and any additional information.*
