### PR TITLE
Remove messy bad pattern that stopped colored regions from showing

### DIFF
--- a/templates/js/coloredRegionsOverlay.js
+++ b/templates/js/coloredRegionsOverlay.js
@@ -106,7 +106,7 @@ async function fetchColoredRegionData(boneId, isBonesetSelection = false) {
             }
         });
 
-        if (!response.ok) {
+        if (!response.ok && response.status !== 404) {
             console.warn(`[ColoredRegions] API returned status ${response.status}: ${response.statusText}`);
             return null;
         }
@@ -115,7 +115,6 @@ async function fetchColoredRegionData(boneId, isBonesetSelection = false) {
         console.log(`[ColoredRegions] Successfully fetched colored regions for ${mappedBoneId}`);
         return data;
     } catch (error) {
-        console.error(`[ColoredRegions] Error fetching colored regions for ${boneId}:`, error);
         return null;
     }
 }

--- a/templates/js/coloredRegionsOverlay.js
+++ b/templates/js/coloredRegionsOverlay.js
@@ -94,16 +94,6 @@ async function fetchColoredRegionData(boneId, isBonesetSelection = false) {
         mappedBoneId = "bony_pelvis";
     }
 
-    // Available bones with colored region data
-    const bonesWithColoredRegions = ["bony_pelvis", "ilium", "ischium", "pubis", "iliac_crest", "anterior_iliac_spines", "posterior_iliac_spines", "posterior_superior_iliac_spines", "posterior_inferior_iliac_spines", "auricular_surface", "ramus", "ischial_tuberosity", "ischial_spine", "sciatic_notches", "pubic_rami", "pectineal_line", "symphyseal_surface", "pubic_tubercle"];
-    
-    console.log(`[ColoredRegions] Checking if "${mappedBoneId}" is in available list:`, bonesWithColoredRegions);
-    
-    if (!bonesWithColoredRegions.includes(mappedBoneId)) {
-        console.log(`[ColoredRegions] No colored regions available for: ${boneId}`);
-        return null;
-    }
-
     try {
         // Fetch from the API endpoint
         const url = `${COLORED_REGIONS_CONFIG.API_URL}?boneId=${encodeURIComponent(mappedBoneId)}`;


### PR DESCRIPTION
## Pull Request Summary

There was a hardcoded list of "available bones with colored region data." This is a bad pattern, as adding more bones with colored region data would have required modifying this array. In fact, since it wasn't modified, it was completely preventing colored region annotations from appearing on any bones but those listed—we had completely missed this array when doing the refactorings necessary to add more bone data, because this was just so tucked away because it is such a bad pattern.