### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,8 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
 
 jobs:
   lint-and-test:


### PR DESCRIPTION
Potential fix for [https://github.com/oss-slu/DigitalBoneBox/security/code-scanning/7](https://github.com/oss-slu/DigitalBoneBox/security/code-scanning/7)

Add an explicit workflow-level `permissions` block in `.github/workflows/lint.yml` so all jobs inherit least-privileged token access.  
For this lint/test pipeline, the minimal required permission is:

- `contents: read`

This preserves current behavior (checkout and read operations still work) while preventing unnecessary write scopes.  
Best placement: directly under the `on:` block (before `jobs:`), so it applies to all jobs unless overridden later.

No imports, methods, or dependencies are needed—this is a YAML configuration-only change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
