### PR TITLE
Clickable image annotations

### DIFF
--- a/templates/js/annotationOverlay.js
+++ b/templates/js/annotationOverlay.js
@@ -114,6 +114,17 @@ export function drawAnnotations(container, annotationsJson) {
       justifyContent: "center",
       whiteSpace: "pre-line",   // show newlines
       textAlign: "center",      // center both lines
+      cursor: "pointer",
+      zIndex: "100",
+      pointerEvents: "auto"
+    });
+
+    el.addEventListener("click", () => {
+        const clickEvent = new CustomEvent("annotationSelected", {
+            detail: {text: a.text_content},
+            bubbles: true
+        });
+        container.dispatchEvent(clickEvent);
     });
 
     labels.appendChild(el);

--- a/templates/js/annotationOverlay.js
+++ b/templates/js/annotationOverlay.js
@@ -15,7 +15,12 @@ function ensureStage(container) {
 export function clearAnnotations(container) {
   if (!container) return;
   const stage = container.querySelector(".annotation-stage");
-  if (stage) stage.remove();
+  if (stage) {
+      if (stage.__resizeObs) {
+          stage.__resizeObs.disconnect();
+      }
+      stage.remove();
+  }
 }
 
 /**
@@ -114,18 +119,31 @@ export function drawAnnotations(container, annotationsJson) {
       justifyContent: "center",
       whiteSpace: "pre-line",   // show newlines
       textAlign: "center",      // center both lines
-      cursor: "pointer",
       zIndex: "100",
       pointerEvents: "auto"
     });
 
-    el.addEventListener("click", () => {
-        const clickEvent = new CustomEvent("annotationSelected", {
-            detail: {text: a.text_content},
-            bubbles: true
-        });
-        container.dispatchEvent(clickEvent);
+    const validateEvent = new CustomEvent("checkAnnotationLink", {
+        detail: { text: a.text_content, isValid: false }
     });
+    document.dispatchEvent(validateEvent);
+
+    if (validateEvent.detail.isValid) {
+        el.classList.add("valid-link");
+        
+        el.addEventListener("click", () => {
+            const clickEvent = new CustomEvent("annotationSelected", {
+                detail: { text: a.text_content, annotationData: a },
+                bubbles: true
+            });
+            container.dispatchEvent(clickEvent);
+        });
+    } else {
+        if (!a.hasLoggedWarning) {
+            console.warn(`Broken link detected: "${a.text_content}" does not map to a known bone.`);
+            a.hasLoggedWarning = true;
+        }
+    }
 
     labels.appendChild(el);
 

--- a/templates/js/dropdowns.js
+++ b/templates/js/dropdowns.js
@@ -2,6 +2,7 @@ import { loadDescription } from "./description.js";
 import {displayBoneImages, showPlaceholder} from "./imageDisplay.js";
 import {clearAnnotations} from "./annotationOverlay.js";
 import {fetchBoneData} from "./api.js";
+import { imageAnnotationToDropdownMap } from "./imageAnnotationToDropdownMap.js";
 
 document.addEventListener("DOMContentLoaded", () => {
   showPlaceholder();
@@ -165,4 +166,47 @@ subboneSelect.addEventListener("change", (e) => {
     showPlaceholder();
   }
 });
+
+  // Image annotation clicked
+  document.addEventListener("annotationSelected", (e) => {
+    let clickedText = e.detail.text;
+    if (!clickedText) return;
+
+    clickedText = clickedText.replace(/\s+/g, " ").trim().toLowerCase();
+
+    const currentBone = boneSelect.value;
+
+    // Mapping the image annotation to dropdown option
+    // If the currently viewed bone has a dictionary, and the clicked text is in it, translate it.
+    if (currentBone && imageAnnotationToDropdownMap[currentBone] && imageAnnotationToDropdownMap[currentBone][clickedText]) {
+        clickedText = imageAnnotationToDropdownMap[currentBone][clickedText];
+    }
+
+    // Check Sub-bones
+    const matchedSubbone = combinedData.subbones.find(
+      sb => sb.name?.toLowerCase() === clickedText
+    );
+
+    if (matchedSubbone) {
+      if (boneSelect.value !== matchedSubbone.bone) {
+         boneSelect.value = matchedSubbone.bone;
+         boneSelect.dispatchEvent(new Event("change")); 
+      }
+      subboneSelect.value = matchedSubbone.id;
+      subboneSelect.dispatchEvent(new Event("change"));
+      return;
+    }
+
+    // Check Bones
+    const matchedBone = combinedData.bones.find(
+      b => b.name?.toLowerCase() === clickedText
+    );
+
+    if (matchedBone) {
+      boneSelect.value = matchedBone.id;
+      boneSelect.dispatchEvent(new Event("change"));
+      return;
+    }
+
+  });
 }

--- a/templates/js/dropdowns.js
+++ b/templates/js/dropdowns.js
@@ -18,6 +18,12 @@ const API_BASE = "http://127.0.0.1:8000";
 /** Helper: fetch images for a bone/sub-bone and render them */
 async function loadBoneImages(boneId, options = {}) {
   const stage = getImageStage();
+
+  if (stage) { 
+      clearAnnotations(stage); 
+      stage.classList.remove("with-annotations"); 
+  }
+
   if (!boneId) {
     showPlaceholder();
     if (stage) { clearAnnotations(stage); stage.classList.remove("with-annotations"); }
@@ -86,9 +92,9 @@ bonesetSelect.addEventListener("change", (e) => {
   boneSelect.disabled = relatedBones.length === 0;
 
   if (!selectedBonesetId || relatedBones.length === 0) {
-    showPlaceholder();
     const stage = getImageStage();
     if (stage) { clearAnnotations(stage); stage.classList.remove("with-annotations"); }
+    showPlaceholder();
     return;
   }
 
@@ -137,9 +143,9 @@ boneSelect.addEventListener("change", (e) => {
     
     loadBoneImages(selectedBoneId, opts);
   } else {
-    showPlaceholder();
     const stage = getImageStage();
     if (stage) { clearAnnotations(stage); stage.classList.remove("with-annotations"); }
+    showPlaceholder();
   }
 });
 
@@ -166,6 +172,25 @@ subboneSelect.addEventListener("change", (e) => {
     showPlaceholder();
   }
 });
+
+  document.addEventListener("checkAnnotationLink", (e) => {
+    let checkText = e.detail.text;
+    if (!checkText) return;
+
+    checkText = checkText.replace(/\s+/g, " ").trim().toLowerCase();
+    const currentBone = boneSelect.value;
+
+    if (currentBone && imageAnnotationToDropdownMap[currentBone] && imageAnnotationToDropdownMap[currentBone][checkText]) {
+        checkText = imageAnnotationToDropdownMap[currentBone][checkText];
+    }
+
+    const isValidSubbone = combinedData.subbones.some(sb => sb.name?.toLowerCase() === checkText);
+    const isValidBone = combinedData.bones.some(b => b.name?.toLowerCase() === checkText);
+
+    if (isValidSubbone || isValidBone) {
+        e.detail.isValid = true; 
+    }
+  });
 
   // Image annotation clicked
   document.addEventListener("annotationSelected", (e) => {

--- a/templates/js/imageAnnotationToDropdownMap.js
+++ b/templates/js/imageAnnotationToDropdownMap.js
@@ -1,0 +1,98 @@
+export const imageAnnotationToDropdownMap = {
+  "ilium": {
+    "anterior superior iliac spine": "anterior iliac spines",
+    "anterior inferior iliac spine": "anterior iliac spines",
+    "posterior superior iliac spine": "posterior iliac spines",
+    "posterior inferior iliac spine": "posterior iliac spines",
+  },
+  "ischium": {
+    "greater sciatic notch": "sciatic notches",
+    "lesser sciatic notch": "sciatic notches",
+  },
+  "pubis": {
+    "superior ramus": "pubic rami",
+    "inferior ramus": "pubic rami",
+    "pectineal line": "pubis pectineal line",
+  },
+  "sternum": {
+    "body": "sternum body",
+    "manubrium": "sternum manubrium",
+    "xiphoid process": "sternum xiphoid process",
+  },
+  "first_rib": {
+    "head": "first rib head and neck",
+    "grooves for subclavian vessels": "first rib grooves for subclavian vessels",
+    "scalene tubercle": "first rib tubercles"
+  },
+  "scapula": {
+    "body": "scapula body"
+  },
+  "atlas": {
+    "posterior tubercle": "atlas anterior and posterior tubercles",
+    "anterior tubercle": "atlas anterior and posterior tubercles",
+    "transverse process": "atlas transverse process",
+    "groove for vertebral artery": "atlas groove for vertebral artery",
+    "articular facet for dens": "atlas articular facet for dens",
+    "lateral mass": "atlas lateral mass",
+  },
+  "cervical": {
+    "spinous process": "cervical spinous process"
+  },
+  "thoracic": {
+    "spinous process": "thoracic spinous process",
+    "superior articular surface": "thoracic articular surfaces",
+    "inferior articular surface": "thoracic articular surfaces"
+  },
+  "lumbar": {
+    "body": "lumbar body",
+    "transverse process": "lumbar transverse process",
+    "spinous process": "lumbar spinous process",
+    "accessory process": "lumbar accessory process",
+    "mammillary process": "lumbar mammillary process",
+    "superior articular surface": "lumbar articular surfaces",
+    "inferior articular surface": "lumbar articular surfaces"
+  },
+  "sacrum_and_coccyx": {
+    "articular surface for ilium": "sacrum and coccyx articular surface for ilium",
+    "superior articular process": "sacrum and coccyx superior articular process",
+    "posterior sacral foramen": "sacrum and coccyx anterior and posterior sacral foramina",
+    "anterior sacral foramen": "sacrum and coccyx anterior and posterior sacral foramina",
+    "median sacral crest": "sacrum and coccyx median sacral crest",
+    "sacran hiatus": "sacrum and coccyx sacran hiatus"
+  },
+  "humerus": {
+    "head": "humerus head",
+    "lesser tubercle": "humerus lesser tubercle",
+    "greater tubercle": "humerus greater tubercle",
+    "anatomical neck": "humerus anatomical neck",
+    "shaft": "humerus shaft",
+    "radial sulcus": "humerus radial sulcus",
+    "deltoid tuberosity": "humerus deltoid tuberosity"
+  },
+  "ulna": {
+    "olecranon process": "ulna olecranon process",
+    "coronoid process": "ulna coronoid process",
+    "ulnar tuberosity": "ulna ulnar tuberosity"
+  },
+  "radius": {
+    "head": "radius head",
+    "radial tuberosity": "radius radial tuberosity",
+    "neck": "radius neck"
+  },
+  "femur": {
+    "head": "femur head",
+    "neck": "femur neck",
+    "shaft": "femur shaft",
+  },
+  "tibia": {
+    "shaft": "tibia shaft",
+    "medial surface": "tibia medial surface",
+    "posterior surface": "tibia posterior surface",
+  },
+  "fibula": {
+    "head": "fibula head",
+    "shaft": "fibula shaft",
+    "medial surface": "fibula medial surface",
+    "posterior surface": "fibula posterior surface",
+  } 
+};

--- a/templates/style.css
+++ b/templates/style.css
@@ -2447,7 +2447,11 @@ button:disabled {
     }
 }
 
-.annotation-label:hover {
+.annotation-label.valid-link {
+    cursor: pointer;
+}
+
+.annotation-label.valid-link:hover {
     color: #007bff;
     transform: scale(1.05);
     z-index: 101

--- a/templates/style.css
+++ b/templates/style.css
@@ -2446,3 +2446,9 @@ button:disabled {
         padding: 8px 6px;
     }
 }
+
+.annotation-label:hover {
+    color: #007bff;
+    transform: scale(1.05);
+    z-index: 101
+}


### PR DESCRIPTION
## Pull Request Summary

closes #207

Now the bone search can be done by just clicking the annotations of the bone or bone part shown in the image.

## Changes

* ``annotationOverlay.js``: added a 'click' event listener that dispatches a custom annotationSelected event.
* ``imageAnnotationToDropdownMap.js``: this new file maps the image annotations of certain bones to the equivalent dropdown option so that the search can be done. This was necessary only because some of the image annotations do not match the exact text of the dropdown option. By the way, this mapping is not complete since some of the bones have messy data currently, like the skull for example. I did all I could.
* ``dropdown.js``: added a event listener to catch the annotationSelected events.
* ``styles.css``: added hovering effect to the image annotations.

## PR Checklist

- [x] Project builds and runs
- [x] Tests and linters pass
- [ ] Any related documentation has been updated, including JSDoc comments or docstrings

## Video


https://github.com/user-attachments/assets/c168cff6-d637-4104-9d34-b7a6b77d2f37


